### PR TITLE
Add missing dependency for nokogiri 1.10.7 with native extensions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN apk upgrade --update \
       gcc \
       libc-dev \
       util-linux \
+      libpng-dev \
       tree \
     && gem install --no-document \
       bundler:1.17.3 \


### PR DESCRIPTION
I had problems running bundle install using the image from DockerHub. It seems to me that libpng-dev is missing. 
 
The error message was:

 Installing nokogiri 1.10.7 with native extensions
 Gem::Ext::BuildError: ERROR: Failed to build gem native extension.
 
     current directory: /usr/lib/ruby/gems/2.4.0/gems/nokogiri-1.10.7/ext/nokogiri
 /usr/bin/ruby -r ./siteconf20200104-141-1e88w7a.rb extconf.rb
 checking if the C compiler accepts ... yes
 Building nokogiri using packaged libraries.
 Using mini_portile version 2.4.0
 checking for gzdopen() in -lz... no
 zlib is missing; necessary for building libxml2
 *** extconf.rb failed ***



